### PR TITLE
Divert /etc/wtop.cfg to $VIRTUAL_ENV/etc/wtop.cfg when in a virtualenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,8 @@ Installation
 ============
 
 This will put logrep and wtop in your executable path, and drop the
-default wtop.cfg file into `/etc/wtop.cfg`.
+default wtop.cfg file into `/etc/wtop.cfg`. In a virtualenv, it will
+be installed in `$VIRTUAL_ENV/etc/wtop.cfg`.
 
 wtop/logrep require Python version 2.6 or greater.
 

--- a/logrep
+++ b/logrep
@@ -237,7 +237,7 @@ def runit():
     x_tmp_file = None
 
     MODE = "grep"
-    cfg = "/etc/wtop.cfg"
+    cfg = None
 
     for o, v in opts:
         if o in ("-h", "-?", "--help"):

--- a/logrep.py
+++ b/logrep.py
@@ -123,7 +123,14 @@ def warn(s):
 def cfg_home():
     if (os.name != "posix"):
         return sys.prefix
-    return "/etc"
+
+    path = "/etc"
+
+    venv = os.environ.get("VIRTUAL_ENV")
+    if venv is not None:
+        path = venv + "/etc"
+
+    return path
 
 
 # yes, this is ugly.


### PR DESCRIPTION
This patch makes `wtop` possible to install in a `virtualenv`.
