### PR TITLE
Add "second" as a recognized field

### DIFF
--- a/logrep
+++ b/logrep
@@ -67,6 +67,7 @@ logrep  [--mode MODE] [--include | --exclude CLASSES] [-H | -R]
                         day
                         hour
                         minute
+                        second
                         country    country name (see Geocoding, below)
                         cc         ISO-639 country code (see below)
 

--- a/logrep.py
+++ b/logrep.py
@@ -292,7 +292,7 @@ def apache2unixtime(t):
 # 21/Jul/2008:18:09:00 -0700   -->   (2008, 7, 21, 18, 9)
 def apache2dateparts(t):
     return (int(t[7:11]), time.strptime(t[3:6], "%b").tm_mon, int(t[0:2]),
-            int(t[12:14]), int(t[15:17]))
+            int(t[12:14]), int(t[15:17]), int(t[18:20]))
 
 
 # keeps a count of seen remote IP addresses. returns
@@ -379,7 +379,7 @@ col_fns = [
     ("url",       ("class",),           classify_url),
     ("timestamp", ("year", "month",
                    "day", "hour",
-                   "minute"),           apache2dateparts),
+                   "minute", "second"), apache2dateparts),
     ("timestamp", ("ts",),              apache2unixtime),
     ("ref",       ("refdom",),          domain),
 ]


### PR DESCRIPTION
Sometimes, you want second-level granularity in output without resorting to using `timestamp` and an `awk` pipeline. This pull request adds support for a `seconds` Apache 2 date-part.
